### PR TITLE
Json docs python syntax fixup

### DIFF
--- a/json.rst
+++ b/json.rst
@@ -51,7 +51,7 @@ Usually, a JSON structure contains a combination of dictionaries and lists conta
                      },
                      'battery': 3600,
                      '3.5mm jack': True,
-                     'SD card slot': True
+                     'SD card slot': True,
                      'colors': ['Black', 'Grey', 'Gold'],
                  },
                  tags=['Smartphone', 'Samsung'])

--- a/json.rst
+++ b/json.rst
@@ -61,11 +61,11 @@ Usually, a JSON structure contains a combination of dictionaries and lists conta
                      'display': {
                         'size': 4.7,
                         'resolution': [750, 1334],
-                        'multi-touch': True
+                        'multi-touch': True,
                      },
                      'battery': 1810,
                      '3.5mm jack': True,
-                     'colors': ['Silver', 'Gold', 'Space Gray', 'Rose Gold']
+                     'colors': ['Silver', 'Gold', 'Space Gray', 'Rose Gold'],
                  },
                  tags=['Smartphone', 'Apple', 'Retina'])
 


### PR DESCRIPTION
Hello,

I noticed that there was some missing syntax in the JSON docs for the  'Samsung Galaxy S7 edge' `Product`. The 1st commit fixes that. The 2nd commit adds extra trailing commas where they aren't strictly necessary: but they should make it harder to make syntax errors when changing parameters in the future.